### PR TITLE
Make sure go_timepicker_base is declared when doing register_resources

### DIFF
--- a/components/class-go-timepicker.php
+++ b/components/class-go-timepicker.php
@@ -139,6 +139,8 @@ class GO_Timepicker
 			$script_config['version'],
 			TRUE
 		);
+
+		wp_localize_script( $this->id_base, 'go_timepicker_base', $this->id_base );
 	}//end register_resources
 
 	/**


### PR DESCRIPTION
The timepicker scripts always requires it, but `go_timepicker_base` was only being declared during `GO_Timepicker::enqueue_scripts()`.

See: https://github.com/GigaOM/gigaom/issues/6168
